### PR TITLE
fixed OperationalError output, reopen on too many handles

### DIFF
--- a/Products/FirebirdDA/db.py
+++ b/Products/FirebirdDA/db.py
@@ -106,16 +106,19 @@ class DB(Shared.DC.ZRDB.THUNK.THUNKED_TM):
                 return items, result
             
             except OperationalError as e:
-                # these errors only occur very briefly
-                # after the firebird server is restarted
-                # soon thereafter, there will be a broken pipe error
                 if e and e.args[0] in ('Can not recv() packets',
+                    # these error only occurs very briefly
+                    # after the firebird server is restarted
+                    # soon thereafter, there will be a broken pipe error
                     '_op_allocate_statement() Invalid db handle'):
                     time.sleep(1)
                     self.close()
                     self.open()
+                elif e and 'too many open handles to database' in e.args[0]:  
+                    self.close()
+                    self.open()
                 else:
-                    raise OperationalError(e)
+                    raise OperationalError(str(e))
             except BrokenPipeError:
                 self.close()
                 self.open()


### PR DESCRIPTION
Hi nakagami!

I messed up a little bit in my last pull request: an OperationalError was not shown correctly in the traceback. I fixed this with this PR. 

Also I ran into the issue of an unresponsive DA with the error "too many handles for database", which I could resolve in the ZMI by closing and reopening the connection. So I excepted this error in the same — not so clean but functioning — way as I handled the error that occurs on a Firebird server restart (in DB's _query_ method)

I use this in a production environment (it seems I'm probably the only one out there doing so currently ;) ), so I'll report back or will create a PR should I run into any troubles.

regards
Georg 