### PR TITLE
Support firebird-driver as an alternative to firebirdsql

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,78 @@
+Changelog
+=========
+
+Unreleased
+----------
+
+Python 3.11+ modernisation
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+- Require Python 3.11 or newer; target Zope 5.
+- Code style: f-strings, ``contextlib.suppress``, proper exception
+  chaining, remove unused imports and dead code.
+- Unify docstring/comment style across the codebase.
+- Extract ISQL meta command translation into a dedicated ``isql_meta``
+  module.
+
+Driver support
+~~~~~~~~~~~~~~
+- Add support for ``firebird-driver`` as alternative to ``firebirdsql``.
+- Automatic DSN format conversion between drivers.
+- Fail fast on an unsupported ``FIREBIRDDA_DRIVER`` value.
+
+Reliability
+~~~~~~~~~~~
+- Simplify connection retry logic and improve error resilience.
+- Raise ``OperationalError`` when retries are exhausted instead of
+  silently failing.
+- Guarantee cursor cleanup by splitting ``query()`` per driver.
+
+Error reporting
+~~~~~~~~~~~~~~~
+- Format ``firebird-driver`` error messages for HTML display.
+- HTML-escape error text and the SQL snippet so the Test tab cannot
+  break on markup or Zope ``TaintedString`` input.
+
+ZMI enhancements
+~~~~~~~~~~~~~~~~
+- Add ISQL ``show`` meta commands in the Test tab: object lists
+  (tables, views, procedures, functions, triggers, generators, domains,
+  exceptions), ``show table NAME`` (columns),
+  ``show procedure/view/trigger/function NAME`` (object source, rendered
+  with whitespace preserved so it copies cleanly), plus ``show version``
+  and ``show database``.
+- Show connection status in the object listing.
+- Include SQL snippet in error messages for Manager callers.
+
+Security
+~~~~~~~~
+- Remove unused connection cache that held plaintext credentials.
+- Restrict SQL snippets in error messages to Manager callers.
+- Gate ISQL meta commands via the Test tab's ``Test Database
+  Connections`` permission instead of a Manager-role check, translating
+  in the Connection's ``manage_test`` (DA layer) rather than the shared
+  ``query()`` path -- so Z SQL Methods are never affected.
+
+0.7.1 (2024-01-04)
+------------------
+- Reopen connection on "too many handles" errors and fix
+  ``OperationalError`` output. [044144c]
+- Add connection retries in ``query()`` method. [8cd2b8b]
+
+0.7.0 (2020-06-20)
+------------------
+- Port to Zope 4 and Python 3. [1e2033f]
+- Refactoring of forms, classifiers and imports. [9c7af69, 0984739, c2f8eda,
+  1e080d7]
+
+0.6.x (2014)
+------------
+- Disable connection pool (do not reuse connections across requests).
+  [3fefc46]
+- Enable ``set_autocommit(True)``. [a2e57f5]
+- Declare ``Products`` namespace package. [3ebe2f8]
+- Add trove classifiers. [0c61502]
+
+0.5.0 (2012-01)
+---------------
+- Initial release by Hajime Nakagami, forked from ``ZKinterbasdbDA 0.5.0``
+  and switched to the ``firebirdsql`` driver. [77e9b51, d7f6336]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.rst
+include CHANGES.rst
 recursive-include Products *.gif *.dtml

--- a/Products/FirebirdDA/DA.py
+++ b/Products/FirebirdDA/DA.py
@@ -12,21 +12,19 @@
 ##############################################################################
 database_type='Firebird'
 
-import sys
-from _thread import allocate_lock
-
-from .db import DB
+from AccessControl.class_init import InitializeClass
+from AccessControl.Permissions import test_database_connections
+from AccessControl.SecurityInfo import ClassSecurityInfo
+from .db import DB, _DRIVER
+from .isql_meta import translate_isql_meta, source_object_name
 import Shared.DC.ZRDB.Connection
 from App.special_dtml import HTMLFile
-
-_connections={}
-_connections_lock=allocate_lock()
 
 
 addConnectionForm=HTMLFile('dtml/connectionAdd',globals())
 
 
-def manage_addFirebirdConnectionForm(self, REQUEST, *args, **kw):
+def manage_addFirebirdConnectionForm(self, REQUEST):
     """Add a connection form"""
     return addConnectionForm(
         self, self, REQUEST,
@@ -42,15 +40,18 @@ def manage_addFirebirdConnection(
     # and the Connection object constructor.
     self._setObject(id, Connection(
         id, title, connection, check))
-    if REQUEST is not None: return self.manage_main(self,REQUEST)
+    if REQUEST is not None:
+        return self.manage_main(self,REQUEST)
 
 class Connection(Shared.DC.ZRDB.Connection.Connection):
-    " "
+    """Zope ZRDB Connection for Interbase/Firebird databases."""
     database_type=database_type
+    driver_name=_DRIVER
     _isAnSQLConnection = True
-    id='%s_database_connection' % database_type
-    meta_type=title='%s Database Connection' % database_type
+    meta_type = f'{database_type} Database Connection'
     zmi_icon = 'fas fa-database'
+
+    security = ClassSecurityInfo()
 
     manage_properties=HTMLFile('dtml/connectionEdit', globals())
 
@@ -59,11 +60,51 @@ class Connection(Shared.DC.ZRDB.Connection.Connection):
             return self._v_database_connection.opened
         return ''
 
-    def connect(self,s):
-        _connections_lock.acquire()
-        try:
-            c=_connections
-            self._v_database_connection=c[s]=DB(s)
-            return self
-        finally:
-            _connections_lock.release()
+    def title_or_id(self):
+        s = self.title or self.id
+        status = 'connected' if self.connected() else 'not connected'
+        return f'{s} ({status})'
+
+    def connect(self, s):
+        self._v_database_connection = DB(s)
+        return self
+
+    @security.protected(test_database_connections)
+    def manage_test(self, query, REQUEST=None):
+        """Translate ISQL meta commands, then run the standard Test query.
+
+        ISQL shortcuts (``show tables`` / ``show procedure NAME`` / ...)
+        are a Test-tab convenience, so the translation lives here in the
+        DA layer -- already gated by the Test tab's own
+        ``test_database_connections`` permission -- rather than in the
+        driver's shared query() path, which also serves Z SQL Methods.
+        """
+        translated = translate_isql_meta(query)
+        if translated is not None:
+            query = translated
+        return super().manage_test(query, REQUEST)
+
+    @security.protected(test_database_connections)
+    def manage_testForm(self, REQUEST=None, **kw):
+        """Standard Test form, with one tweak for the source-listing
+        ``show <kind> NAME`` commands (procedure/view/trigger/function).
+
+        Those return the object's body in a single result cell whose DOM
+        text already holds the newlines, but the ZMI table renders cells
+        with ``white-space: normal`` -- which collapses the code on screen
+        and, worse, makes a copy come out collapsed too. For such a query
+        we append a small stylesheet switching the result cell to
+        ``white-space: pre-wrap``, so the source shows and copies properly
+        formatted. Everything else is the stock form.
+        """
+        html = super().manage_testForm(REQUEST, **kw)
+        if REQUEST is not None and source_object_name(REQUEST.get('query') or ''):
+            html = (
+                '%s\n<style>main table.table td '
+                '{white-space: pre-wrap; font-family: monospace; tab-size: 4;}'
+                '</style>'
+                % html)
+        return html
+
+
+InitializeClass(Connection)

--- a/Products/FirebirdDA/db.py
+++ b/Products/FirebirdDA/db.py
@@ -39,7 +39,8 @@ if _DRIVER == "firebird-driver":
     from firebird.driver import DatabaseError as Error
     from firebird.driver import InterfaceError
     from firebird.driver import connect as _raw_connect
-    from firebird.driver.core import TPB
+    from firebird.driver import tpb as _make_tpb
+    from firebird.driver.types import Isolation as _Isolation
 
     # libfbclient installs a C-level SIGTERM handler via sigaction()
     # on the first connect(), which swallows SIGTERM entirely.
@@ -321,8 +322,9 @@ class DB(Shared.DC.ZRDB.THUNK.THUNKED_TM):
         if _DRIVER == "firebirdsql":
             self.conn.set_autocommit(True)
         else:
-            tpb = TPB(auto_commit=True)
-            self.conn.default_tpb = tpb.get_buffer()
+            self.conn.main_transaction.default_tpb = _make_tpb(
+                _Isolation.READ_COMMITTED
+            )
         self.opened = DateTime()
 
     def close(self):
@@ -366,6 +368,20 @@ class DB(Shared.DC.ZRDB.THUNK.THUNKED_TM):
                     r = c.fetchmany(max_rows - len(result))
                     if r:
                         result += r
+
+            if _DRIVER == "firebird-driver":
+                # Commit so the next query gets a fresh READ_COMMITTED
+                # snapshot. Not needed for firebirdsql (autocommit is on).
+                self.conn.commit()
+        except Exception:
+            if _DRIVER == "firebird-driver":
+                # Rollback so the failed query does not leave an open
+                # transaction behind. Accumulated open transactions prevent
+                # the OAT from advancing, eventually triggering a server-
+                # side "connection shutdown" (GDS 335544856).
+                with contextlib.suppress(Exception):
+                    self.conn.rollback()
+            raise
         finally:
             with contextlib.suppress(Exception):
                 c.close()

--- a/Products/FirebirdDA/db.py
+++ b/Products/FirebirdDA/db.py
@@ -10,115 +10,449 @@
 # FOR A PARTICULAR PURPOSE
 #
 ##############################################################################
+import contextlib
+import datetime
+import decimal
 import os
-import firebirdsql
-import Shared.DC.ZRDB.THUNK
-from DateTime import DateTime
+import re
+import signal
 import time
 
-from firebirdsql import OperationalError
+import Shared.DC.ZRDB.THUNK
+from DateTime import DateTime
 
-with_system_flag=0
-CONNECTION_RETRIES = 5
+_DRIVER = os.environ.get("FIREBIRDDA_DRIVER", "").strip()
+
+if not _DRIVER:
+    try:
+        import firebirdsql
+
+        _DRIVER = "firebirdsql"
+    except ImportError:
+        _DRIVER = "firebird-driver"
+
+if _DRIVER == "firebird-driver":
+    import ctypes
+    import ctypes.util
+    import threading
+
+    from firebird.driver import DatabaseError as Error
+    from firebird.driver import InterfaceError
+    from firebird.driver import connect as _raw_connect
+    from firebird.driver.core import TPB
+
+    # libfbclient installs a C-level SIGTERM handler via sigaction()
+    # on the first connect(), which swallows SIGTERM entirely.
+    # Python's signal.getsignal() doesn't see it (it only tracks
+    # Python-level handlers).  We save the OS-level handler before
+    # connect() and restore it afterwards.
+    _libc = ctypes.CDLL(ctypes.util.find_library("c") or None, use_errno=True)
+    _sigaction = getattr(_libc, "sigaction", None)
+    _sigaction_lock = threading.Lock()
+    _SIGACTION_BUFFER_SIZE = 4096
+
+    class _SigactionBuffer(ctypes.Union):
+        _fields_ = [
+            ("_alignment", ctypes.c_longdouble),
+            ("_storage", ctypes.c_ubyte * _SIGACTION_BUFFER_SIZE),
+        ]
+
+    if _sigaction is not None:
+        _sigaction.argtypes = (ctypes.c_int, ctypes.c_void_p, ctypes.c_void_p)
+        _sigaction.restype = ctypes.c_int
+
+    def _call_sigaction(signum, act, oldact):
+        if _sigaction is None:
+            return False
+        ctypes.set_errno(0)
+        return _sigaction(signum, act, oldact) == 0
+
+    def _connect(**kwargs):
+        if _sigaction is None:
+            return _raw_connect(**kwargs)
+
+        saved = _SigactionBuffer()
+        with _sigaction_lock:
+            have_saved_handler = _call_sigaction(
+                signal.SIGTERM, None, ctypes.byref(saved)
+            )
+            try:
+                return _raw_connect(**kwargs)
+            finally:
+                if have_saved_handler:
+                    _call_sigaction(signal.SIGTERM, ctypes.byref(saved), None)
+
+    # GDS codes that indicate a lost or unusable connection where
+    # a reconnect + retry is appropriate.
+    RECONNECT_GDS_CODES: frozenset[int] = frozenset(
+        {
+            335544648,  # connection lost to database (pipe)
+            335544721,  # network error
+            335544722,  # Unable to complete network request
+            335544726,  # Error reading data from the connection
+            335544727,  # Error writing data to the connection
+            335544741,  # connection lost to database
+            335544761,  # too many open handles to database
+            335544856,  # connection shutdown
+        }
+    )
+
+    class OperationalError(Exception):
+        """FirebirdDA operational error for the firebird-driver backend.
+
+        Does NOT inherit from firebird.base.types.Error, because that class
+        defines __getattr__ such that any unset attribute returns None —
+        including __call__.  This crashes Zope's DocumentTemplate:
+        safe_callable() checks hasattr(e, '__call__') (which returns True)
+        and then calls e() on the exception instance.  Since e.__call__ is
+        None, rendering <dtml-var error_value> in the ZMI Test tab crashes
+        with "TypeError: 'NoneType' object is not callable" — without the
+        actual Firebird error message ever reaching the user.
+
+        The original firebird-driver exception is chained via __cause__.
+        """
+
+        pass
+
+    # cursor.description type_code → ZRDB type character.
+    # firebird-driver returns Python types (int, float, ...).
+    def _zrdb_type(type_code, scale):
+        if type_code is int:
+            return "i"
+        if type_code in (float, decimal.Decimal):
+            return "n"
+        if type_code in (datetime.date, datetime.datetime, datetime.time):
+            return "d"
+        return "s"
+
+elif _DRIVER == "firebirdsql":
+    import firebirdsql
+    from firebirdsql import OperationalError
+
+    _connect = firebirdsql.connect
+    Error = firebirdsql.Error
+
+    # cursor.description type_code → ZRDB type character.
+    # firebirdsql returns ISC numeric type codes.
+    _INTEGER_OR_DECIMAL_CODES = frozenset(
+        {
+            firebirdsql.SQL_TYPE_SHORT,  # 500
+            firebirdsql.SQL_TYPE_LONG,  # 496
+            firebirdsql.SQL_TYPE_INT64,  # 580
+            firebirdsql.SQL_TYPE_INT128,  # 32752
+        }
+    )
+    _FLOAT_CODES = frozenset(
+        {
+            firebirdsql.SQL_TYPE_FLOAT,  # 482
+            firebirdsql.SQL_TYPE_DOUBLE,  # 480
+            firebirdsql.SQL_TYPE_D_FLOAT,  # 530
+            firebirdsql.SQL_TYPE_DEC64,  # 32760
+            firebirdsql.SQL_TYPE_DEC128,  # 32762
+            firebirdsql.SQL_TYPE_DEC_FIXED,  # 32758
+        }
+    )
+    _DATE_CODES = frozenset(
+        {
+            firebirdsql.SQL_TYPE_DATE,  # 570
+            firebirdsql.SQL_TYPE_TIME,  # 560
+            firebirdsql.SQL_TYPE_TIMESTAMP,  # 510
+            firebirdsql.SQL_TYPE_TIMESTAMP_TZ,  # 32754
+            firebirdsql.SQL_TYPE_TIME_TZ,  # 32756
+        }
+    )
+
+    def _zrdb_type(type_code, scale):
+        if type_code in _INTEGER_OR_DECIMAL_CODES:
+            return "i" if scale == 0 else "n"
+        if type_code in _FLOAT_CODES:
+            return "n"
+        if type_code in _DATE_CODES:
+            return "d"
+        return "s"
+
+
+_FIREBIRDSQL_RETRIES = 5
+_FIREBIRD_DRIVER_RETRIES = 2
+_FIREBIRD_DRIVER_RETRY_DELAY = 0.5
+
+# Substring fallback markers (lower-cased) used to recognise
+# connection-loss situations on exceptions that do not carry
+# gds_codes (e.g. Python-level socket errors raised before the
+# server could return a status vector).
+_RECONNECT_MARKERS = (
+    "broken pipe",
+    "connection lost",
+    "connection closed",
+    "network error",
+    "too many open handles",
+    "shutdown",
+)
+
+
+def _is_firebird_driver_connection_lost(exc):
+    """True if exc indicates a transient connection-loss situation
+    where a reconnect + single retry makes sense."""
+    # BrokenPipeError is a subclass of ConnectionError.
+    if isinstance(exc, (ConnectionError, InterfaceError)):
+        return True
+    codes = getattr(exc, "gds_codes", None) or ()
+    if any(c in RECONNECT_GDS_CODES for c in codes):
+        return True
+    msg = str(exc).lower()
+    return any(m in msg for m in _RECONNECT_MARKERS)
+
+
+def _exception_message(exc):
+    """Return a defensive string message for exceptions with optional args."""
+    args = getattr(exc, "args", None)
+    msg = str(args[0] if args else exc)
+    if not msg:
+        msg = exc.__class__.__name__
+    return msg
+
+
+def _caller_is_manager():
+    """True if the current Zope user has the Manager role.
+
+    Gates a single Manager-only convenience in this DA: including the
+    offending SQL snippet in error messages.  Non-Manager callers get
+    sanitised errors without the SQL.
+
+    Uses has_role(('Manager',)) instead of checkPermission because
+    checkPermission needs an Acquisition-wrapped context object,
+    which the DB instance does not have.
+    """
+    try:
+        from AccessControl import getSecurityManager
+
+        return getSecurityManager().getUser().has_role(("Manager",))
+    except Exception:
+        # Outside a Zope request (unit test, startup) be conservative:
+        # no SQL in errors.
+        return False
+
+
+def _format_firebirdsql_error(exc):
+    """Format a firebirdsql exception as an HTML-safe error message."""
+    msg = _exception_message(exc).replace("\n", "<br/>")
+    op = OperationalError(msg)
+    op.args = (msg,)
+    return op
+
+
+def _format_firebird_driver_error(exc, query_string, include_sql=False):
+    """Format a firebird-driver exception as a multi-line message."""
+    parts = ["Firebird query failed."]
+
+    orig = str(exc).strip()
+    if orig:
+        parts.append(f"Error: {orig.replace(chr(10), '<br/>')}")
+
+    sqlstate = getattr(exc, "sqlstate", None)
+    if sqlstate:
+        if isinstance(sqlstate, bytes):
+            sqlstate = sqlstate.decode("ascii", "replace")
+        parts.append(f"SQLSTATE: {sqlstate}")
+
+    sqlcode = getattr(exc, "sqlcode", None)
+    if sqlcode is not None:
+        parts.append(f"SQLCODE: {sqlcode}")
+
+    if query_string and include_sql:
+        snippet = query_string.strip()
+        max_len = 2000
+        if len(snippet) > max_len:
+            snippet = snippet[:max_len] + "\n  ... (truncated)"
+        parts.append(f"SQL: {snippet}")
+
+    return "<br/>".join(parts)
+
 
 def fetchallmap(c):
+    """Fetch all rows from cursor c as a list of {column_name: value} dicts.
+
+    Not called anywhere in this product and not exposed to Zope.
+    Kept for backward compatibility with third-party code that may
+    import it directly.
+    """
     desc = c.description
     r = []
     for row in c.fetchall():
         d = {}
-        for i in range(len(desc)):
-            key = str(desc[i][0])
-            try: d[key] = row[i].strip()
-            except: d[key] = row[i]
+        for col, value in zip(desc, row):
+            key = str(col[0])
+            try:
+                d[key] = value.strip()
+            except AttributeError:
+                d[key] = value
         r.append(d)
     return r
 
+
+def _convert_dsn(dsn):
+    """Convert firebirdsql DSN format to firebird-driver format.
+
+    firebirdsql:      host:port/path  host:/path
+    firebird-driver:  host/port:path  host:path
+    """
+    m = re.match(r"^([^:/]+)(?::(\d+))?[:/](.+)$", dsn)
+    if not m:
+        raise ValueError(f"Unrecognized DSN format: {dsn!r}")
+    host, port, path = m.groups()
+    if port:
+        return f"{host}/{port}:{path}"
+    # /alias (single component) -> alias; /path/to/db stays as-is
+    if path.startswith("/") and "/" not in path[1:]:
+        path = path[1:]
+    return f"{host}:{path}"
+
+
 class DB(Shared.DC.ZRDB.THUNK.THUNKED_TM):
-    database_error=firebirdsql.Error
-    opened=None
+    database_error = Error
+    opened = None
+
+    conn = None
 
     def open(self):
-        self.conn = firebirdsql.connect(**self.conn_args)
-        self.conn.set_autocommit(True)
-        self.opened=DateTime()
+        if self.conn is not None:
+            self.close()
+        self.conn = _connect(**self.conn_args)
+        if _DRIVER == "firebirdsql":
+            self.conn.set_autocommit(True)
+        else:
+            tpb = TPB(auto_commit=True)
+            self.conn.default_tpb = tpb.get_buffer()
+        self.opened = DateTime()
 
     def close(self):
-        self.conn.close()
+        conn = self.conn
+        self.conn = None
         self.opened = None
+        if conn is None:
+            return
+        with contextlib.suppress(Exception):
+            conn.close()
 
-    def __init__(self,connection):
-        conn_args = {}
-        for s in connection.split():
-            k,v = s.split('=', 1)
-            conn_args[k] = v
+    def __init__(self, connection):
+        conn_args = dict(s.split("=", 1) for s in connection.split())
+        if _DRIVER == "firebird-driver" and "dsn" in conn_args:
+            conn_args["database"] = _convert_dsn(conn_args.pop("dsn"))
         self.conn_args = conn_args
-        self.db_conn = []
         self.open()
 
-    def query(self,query_string, max_rows=9999999):
-        for i in range(CONNECTION_RETRIES):
-            # if necessary: retries for broken pipe,
-            # invalid db handle or recv() packets problem
-            # which can occur when the firebird server is restarted
-            try:
-                c = self.conn.cursor()
+    def _execute_query(self, query_string, max_rows):
+        """Execute query_string on self.conn and return (items, rows)."""
+        c = self.conn.cursor()
+        try:
+            queries = [q for q in (s.strip() for s in query_string.split("\0")) if q]
+            if not queries:
+                raise OperationalError("empty query")
+            desc = None
+            result = []
+            for qs in queries:
+                c.execute(qs)
 
-                queries=filter(None, [q.strip() for q in query_string.split('\0')])
-                if not queries:
-                    raise OperationalError('empty query')
-                desc=None
-                result=[]
-                for qs in queries:
-                    c.execute(qs)
-
-                    d=c.description
-                    if d is None: continue
-                    if desc is None: desc=d
-                    elif d != desc:
-                        raise OperationalError(
-                            'Multiple incompatible selects in '
-                            'multiple sql-statement query'
-                            )
-                    if len(result) < max_rows:
-                        r = c.fetchmany(max_rows-len(result))
-                        if r:
-                            result += r
-
-
+                d = c.description
+                if d is None:
+                    continue
                 if desc is None:
-                    return (), ()
+                    desc = d
+                elif d != desc:
+                    raise OperationalError(
+                        "Multiple incompatible selects in multiple sql-statement query"
+                    )
+                if len(result) < max_rows:
+                    r = c.fetchmany(max_rows - len(result))
+                    if r:
+                        result += r
+        finally:
+            with contextlib.suppress(Exception):
+                c.close()
 
-                items=[]
-                for name, type, width, ds, p, scale, null_ok in desc:
-                    if type=='NUMBER':
-                        if scale==0: type='i'
-                        else: type='n'
-                    elif type=='DATE':
-                        type='d'
-                    else: type='s'
-                    items.append({
-                        'name': name,
-                        'type': type,
-                        'width': width,
-                        'null': null_ok,
-                        })
+        if desc is None:
+            return (), ()
 
-                return items, result
-            
+        items = []
+        for name, type_code, width, ds, p, scale, null_ok in desc:
+            items.append(
+                {
+                    "name": name,
+                    "type": _zrdb_type(type_code, scale),
+                    "width": width,
+                    "null": null_ok,
+                }
+            )
+
+        return items, result
+
+    def query(self, query_string, max_rows=9999999):
+        """Public entry point — dispatch to the active driver backend."""
+        if _DRIVER == "firebirdsql":
+            return self._query_firebirdsql(query_string, max_rows)
+        return self._query_firebird_driver(query_string, max_rows)
+
+    def _query_firebirdsql(self, query_string, max_rows):
+        """Run query via firebirdsql with retries for transient errors."""
+        last_exc = None
+        for i in range(_FIREBIRDSQL_RETRIES):
+            try:
+                return self._execute_query(query_string, max_rows)
+
             except OperationalError as e:
-                if e and e.args[0] in ('Can not recv() packets',
-                    # these error only occurs very briefly
-                    # after the firebird server is restarted
-                    # soon thereafter, there will be a broken pipe error
-                    '_op_allocate_statement() Invalid db handle'):
+                last_exc = e
+                msg = _exception_message(e)
+                if msg in (
+                    "Can not recv() packets",
+                    "_op_allocate_statement() Invalid db handle",
+                ):
                     time.sleep(1)
                     self.close()
                     self.open()
-                elif e and 'too many open handles to database' in e.args[0]:  
+                elif "too many open handles to database" in msg:
                     self.close()
                     self.open()
                 else:
-                    raise OperationalError(str(e))
-            except BrokenPipeError:
+                    raise _format_firebirdsql_error(e) from e
+            except Error as e:
+                raise _format_firebirdsql_error(e) from e
+            except BrokenPipeError as e:
+                last_exc = e
                 self.close()
                 self.open()
+        exc = _format_firebirdsql_error(last_exc)
+        exc.args = (
+            f"Firebird query failed after {_FIREBIRDSQL_RETRIES} retries: "
+            + exc.args[0],
+        )
+        raise exc from last_exc
+
+    def _query_firebird_driver(self, query_string, max_rows):
+        """Run query via firebird-driver with retry and error enrichment."""
+        last_exc = None
+        for attempt in range(_FIREBIRD_DRIVER_RETRIES):
+            try:
+                if self.opened is None:
+                    self.open()
+                return self._execute_query(query_string, max_rows)
+
+            except (Error, ConnectionError) as e:
+                if not _is_firebird_driver_connection_lost(e):
+                    # SQL / logic error: enrich and re-raise.
+                    msg = _format_firebird_driver_error(
+                        e, query_string, include_sql=_caller_is_manager()
+                    )
+                    raise OperationalError(msg) from e
+                last_exc = e
+                self.close()
+                if attempt < _FIREBIRD_DRIVER_RETRIES - 1:
+                    time.sleep(_FIREBIRD_DRIVER_RETRY_DELAY)
+
+        msg = (
+            "Connection to Firebird lost; reconnect attempts "
+            "exhausted.\n\n"
+            + _format_firebird_driver_error(
+                last_exc, query_string, include_sql=_caller_is_manager()
+            )
+        )
+        raise OperationalError(msg) from last_exc

--- a/Products/FirebirdDA/db.py
+++ b/Products/FirebirdDA/db.py
@@ -13,6 +13,7 @@
 import contextlib
 import datetime
 import decimal
+import html
 import os
 import re
 import signal
@@ -30,6 +31,12 @@ if not _DRIVER:
         _DRIVER = "firebirdsql"
     except ImportError:
         _DRIVER = "firebird-driver"
+
+if _DRIVER not in ("firebirdsql", "firebird-driver"):
+    raise RuntimeError(
+        f"Unsupported FIREBIRDDA_DRIVER {_DRIVER!r}; expected "
+        "'firebirdsql' or 'firebird-driver'"
+    )
 
 if _DRIVER == "firebird-driver":
     import ctypes
@@ -234,9 +241,18 @@ def _caller_is_manager():
         return False
 
 
+def _html_safe(value):
+    """Normalise to str, HTML-escape, then render newlines as <br/>.
+
+    Defends against Zope TaintedString input (SQL containing < or >)
+    and keeps unescaped error/SQL text out of the HTML output.
+    """
+    return html.escape(str(value), quote=True).replace("\n", "<br/>")
+
+
 def _format_firebirdsql_error(exc):
     """Format a firebirdsql exception as an HTML-safe error message."""
-    msg = _exception_message(exc).replace("\n", "<br/>")
+    msg = _html_safe(_exception_message(exc))
     op = OperationalError(msg)
     op.args = (msg,)
     return op
@@ -248,24 +264,24 @@ def _format_firebird_driver_error(exc, query_string, include_sql=False):
 
     orig = str(exc).strip()
     if orig:
-        parts.append(f"Error: {orig.replace(chr(10), '<br/>')}")
+        parts.append(f"Error: {_html_safe(orig)}")
 
     sqlstate = getattr(exc, "sqlstate", None)
     if sqlstate:
         if isinstance(sqlstate, bytes):
             sqlstate = sqlstate.decode("ascii", "replace")
-        parts.append(f"SQLSTATE: {sqlstate}")
+        parts.append(f"SQLSTATE: {_html_safe(sqlstate)}")
 
     sqlcode = getattr(exc, "sqlcode", None)
     if sqlcode is not None:
-        parts.append(f"SQLCODE: {sqlcode}")
+        parts.append(f"SQLCODE: {_html_safe(sqlcode)}")
 
     if query_string and include_sql:
-        snippet = query_string.strip()
+        snippet = str(query_string).strip()
         max_len = 2000
         if len(snippet) > max_len:
             snippet = snippet[:max_len] + "\n  ... (truncated)"
-        parts.append(f"SQL: {snippet}")
+        parts.append(f"SQL: {_html_safe(snippet)}")
 
     return "<br/>".join(parts)
 

--- a/Products/FirebirdDA/dtml/connectionEdit.dtml
+++ b/Products/FirebirdDA/dtml/connectionEdit.dtml
@@ -22,8 +22,20 @@
     </div>
     </td>
     <td align="left" valign="top">
-    <input type="text" name="title" size="40" 
+    <input type="text" name="title" size="40"
      value="&dtml-title;" />
+    </td>
+  </tr>
+  <tr>
+    <td align="left" valign="top">
+    <div class="form-label">
+    Driver
+    </div>
+    </td>
+    <td align="left" valign="top">
+    <div class="form-text">
+    &dtml-driver_name;
+    </div>
     </td>
   </tr>
   <tr>
@@ -35,8 +47,7 @@
     <td align="left" valign="top">
     <div class="form-text">
     <em>
-          ex)<br>
-          dsn=host:/path user=myname password=pass
+          format: dsn=host[:port]/path user=myname password=pass
     </em>
     </div>
     <div class="form-text">

--- a/Products/FirebirdDA/isql_meta.py
+++ b/Products/FirebirdDA/isql_meta.py
@@ -1,0 +1,241 @@
+##############################################################################
+#
+# Copyright (c) 2001 Zope Corporation and Contributors. All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.0 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE
+#
+##############################################################################
+"""ISQL meta command translation.
+
+isql supports a handful of meta commands (``show tables``,
+``show table NAME``, ``show procedures``, ``show procedure NAME``,
+``show version``, ...) that plain Firebird SQL does not understand. In
+the ZMI Test tab of the FirebirdDA Connection we translate them into
+real system-table queries so they work the same way as in isql. Object
+lists (tables, views, procedures, functions, triggers, generators,
+domains, exceptions) and the ``show version``/``show database`` info
+commands are exact matches in ``ISQL_META_COMMANDS``. The parameterised
+variants are handled by ``translate_isql_meta()``: ``show table NAME``
+(column list) and ``show procedure/view/trigger/function NAME`` (the
+object's source, defined in ``SOURCE_OBJECTS`` and rendered as a <pre>
+block by the DA layer).
+"""
+import re
+
+
+ISQL_META_COMMANDS = {
+    'show tables': (
+        "SELECT TRIM(RDB$RELATION_NAME) AS TABLE_NAME "
+        "FROM RDB$RELATIONS "
+        "WHERE RDB$SYSTEM_FLAG = 0 AND RDB$VIEW_BLR IS NULL "
+        "ORDER BY RDB$RELATION_NAME"
+    ),
+    'show views': (
+        "SELECT TRIM(RDB$RELATION_NAME) AS VIEW_NAME "
+        "FROM RDB$RELATIONS "
+        "WHERE RDB$SYSTEM_FLAG = 0 AND RDB$VIEW_BLR IS NOT NULL "
+        "ORDER BY RDB$RELATION_NAME"
+    ),
+    'show procedures': (
+        "SELECT TRIM(RDB$PROCEDURE_NAME) AS PROCEDURE_NAME "
+        "FROM RDB$PROCEDURES "
+        "WHERE RDB$SYSTEM_FLAG = 0 "
+        "ORDER BY RDB$PROCEDURE_NAME"
+    ),
+    'show functions': (
+        "SELECT TRIM(RDB$FUNCTION_NAME) AS FUNCTION_NAME "
+        "FROM RDB$FUNCTIONS "
+        "WHERE RDB$SYSTEM_FLAG = 0 "
+        "ORDER BY RDB$FUNCTION_NAME"
+    ),
+    'show triggers': (
+        "SELECT TRIM(RDB$TRIGGER_NAME) AS TRIGGER_NAME "
+        "FROM RDB$TRIGGERS "
+        "WHERE RDB$SYSTEM_FLAG = 0 "
+        "ORDER BY RDB$TRIGGER_NAME"
+    ),
+    'show generators': (
+        "SELECT TRIM(RDB$GENERATOR_NAME) AS GENERATOR_NAME "
+        "FROM RDB$GENERATORS "
+        "WHERE RDB$SYSTEM_FLAG = 0 "
+        "ORDER BY RDB$GENERATOR_NAME"
+    ),
+    'show domains': (
+        "SELECT TRIM(RDB$FIELD_NAME) AS DOMAIN_NAME "
+        "FROM RDB$FIELDS "
+        "WHERE RDB$SYSTEM_FLAG = 0 "
+        "AND RDB$FIELD_NAME NOT STARTING WITH 'RDB$' "
+        "ORDER BY RDB$FIELD_NAME"
+    ),
+    'show exceptions': (
+        "SELECT TRIM(RDB$EXCEPTION_NAME) AS EXCEPTION_NAME "
+        "FROM RDB$EXCEPTIONS "
+        "WHERE RDB$SYSTEM_FLAG = 0 "
+        "ORDER BY RDB$EXCEPTION_NAME"
+    ),
+    'show version': (
+        "SELECT rdb$get_context('SYSTEM', 'ENGINE_VERSION') AS VERSION "
+        "FROM RDB$DATABASE"
+    ),
+    'show database': (
+        "SELECT "
+        "rdb$get_context('SYSTEM', 'DB_NAME') AS DATABASE_NAME, "
+        "rdb$get_context('SYSTEM', 'ENGINE_VERSION') AS ENGINE_VERSION, "
+        "rdb$get_context('SYSTEM', 'CURRENT_USER') AS CURRENT_USER "
+        "FROM RDB$DATABASE"
+    ),
+}
+
+
+# Firebird RDB$FIELDS.RDB$FIELD_TYPE -> readable SQL type name.
+# Covers the common column types; unknown types are emitted as a
+# numeric code.
+FB_FIELD_TYPE_CASE = """
+  CASE f.RDB$FIELD_TYPE
+    WHEN 7 THEN
+      CASE f.RDB$FIELD_SUB_TYPE
+        WHEN 1 THEN 'NUMERIC(' || f.RDB$FIELD_PRECISION || ',' ||
+                    (-f.RDB$FIELD_SCALE) || ')'
+        WHEN 2 THEN 'DECIMAL(' || f.RDB$FIELD_PRECISION || ',' ||
+                    (-f.RDB$FIELD_SCALE) || ')'
+        ELSE 'SMALLINT'
+      END
+    WHEN 8 THEN
+      CASE f.RDB$FIELD_SUB_TYPE
+        WHEN 1 THEN 'NUMERIC(' || f.RDB$FIELD_PRECISION || ',' ||
+                    (-f.RDB$FIELD_SCALE) || ')'
+        WHEN 2 THEN 'DECIMAL(' || f.RDB$FIELD_PRECISION || ',' ||
+                    (-f.RDB$FIELD_SCALE) || ')'
+        ELSE 'INTEGER'
+      END
+    WHEN 10 THEN 'FLOAT'
+    WHEN 12 THEN 'DATE'
+    WHEN 13 THEN 'TIME'
+    WHEN 14 THEN 'CHAR(' || f.RDB$CHARACTER_LENGTH || ')'
+    WHEN 16 THEN
+      CASE f.RDB$FIELD_SUB_TYPE
+        WHEN 1 THEN 'NUMERIC(' || f.RDB$FIELD_PRECISION || ',' ||
+                    (-f.RDB$FIELD_SCALE) || ')'
+        WHEN 2 THEN 'DECIMAL(' || f.RDB$FIELD_PRECISION || ',' ||
+                    (-f.RDB$FIELD_SCALE) || ')'
+        ELSE 'BIGINT'
+      END
+    WHEN 27 THEN 'DOUBLE PRECISION'
+    WHEN 35 THEN 'TIMESTAMP'
+    WHEN 37 THEN 'VARCHAR(' || f.RDB$CHARACTER_LENGTH || ')'
+    WHEN 261 THEN
+      'BLOB SUB_TYPE ' ||
+      CASE f.RDB$FIELD_SUB_TYPE
+        WHEN 0 THEN 'BINARY'
+        WHEN 1 THEN 'TEXT'
+        ELSE CAST(f.RDB$FIELD_SUB_TYPE AS VARCHAR(10))
+      END
+    ELSE 'TYPE_' || CAST(f.RDB$FIELD_TYPE AS VARCHAR(10))
+  END
+"""
+
+# Query for "show table NAME": column list with type, length, nullability,
+# default. {name} is filled in by the translator with the validated table
+# name (always pre-validated, so no SQL-injection risk).
+SHOW_TABLE_SQL = (
+    "SELECT "
+    "TRIM(rf.RDB$FIELD_NAME) AS FIELD_NAME, "
+    + FB_FIELD_TYPE_CASE.strip() + " AS FIELD_TYPE, "
+    "CASE WHEN COALESCE(rf.RDB$NULL_FLAG, f.RDB$NULL_FLAG) = 1 "
+    "THEN 'NOT NULL' ELSE '' END AS NULLABLE, "
+    "COALESCE(rf.RDB$DEFAULT_SOURCE, f.RDB$DEFAULT_SOURCE) AS DEFAULT_VALUE "
+    "FROM RDB$RELATION_FIELDS rf "
+    "JOIN RDB$FIELDS f ON rf.RDB$FIELD_SOURCE = f.RDB$FIELD_NAME "
+    "WHERE rf.RDB$RELATION_NAME = '{name}' "
+    "ORDER BY rf.RDB$FIELD_POSITION"
+)
+
+# Identifier fragment shared by the "show <kind> NAME" commands: a quoted
+# "Name" (case kept) or an unquoted name (upper-cased by the translator).
+_NAME_RE = r'(?:"(?P<quoted>[^"]+)"|(?P<unquoted>[A-Za-z][A-Za-z0-9_$]*))'
+
+SHOW_TABLE_RE = re.compile(
+    r'^show\s+table\s+' + _NAME_RE + r'\s*;?\s*$', re.IGNORECASE)
+
+# "show procedure/view/trigger/function NAME": the object's source body,
+# returned as a single SOURCE cell and rendered <pre> by the DA layer
+# (Connection.manage_testForm). Maps the keyword to (system table, name
+# column, source column). RDB$FUNCTION_SOURCE requires Firebird 3+.
+SOURCE_OBJECTS = {
+    'procedure': ('RDB$PROCEDURES', 'RDB$PROCEDURE_NAME', 'RDB$PROCEDURE_SOURCE'),
+    'view':      ('RDB$RELATIONS',  'RDB$RELATION_NAME',  'RDB$VIEW_SOURCE'),
+    'trigger':   ('RDB$TRIGGERS',   'RDB$TRIGGER_NAME',   'RDB$TRIGGER_SOURCE'),
+    'function':  ('RDB$FUNCTIONS',  'RDB$FUNCTION_NAME',  'RDB$FUNCTION_SOURCE'),
+}
+
+SHOW_SOURCE_RE = re.compile(
+    r'^show\s+(?P<kind>' + '|'.join(SOURCE_OBJECTS) + r')\s+'
+    + _NAME_RE + r'\s*;?\s*$', re.IGNORECASE)
+
+
+def _validated_object_name(match):
+    """Return the validated identifier from a "show <kind> NAME" match.
+
+    Unquoted identifiers are upper-cased (Firebird stores them that way
+    in the system tables); quoted identifiers keep their case. Returns
+    None if the name contains an apostrophe -- a string terminator and
+    our SQL-injection safety net. Quoted identifiers may legitimately
+    contain spaces etc., so only the apostrophe is blocked.
+    """
+    quoted = match.group('quoted')
+    name = quoted if quoted is not None else match.group('unquoted').upper()
+    if "'" in name:
+        return None
+    return name
+
+
+def translate_isql_meta(query_string):
+    """Translate an ISQL meta command to a Firebird SQL query.
+
+    If query_string matches a known ISQL meta command
+    (case-insensitive, whitespace normalised, optional trailing ';'),
+    return the corresponding Firebird SQL query.  Otherwise return
+    None.
+    """
+    stripped = query_string.strip()
+    # 1) Exact matches (show tables / show procedures / show version / ...)
+    key = ' '.join(stripped.rstrip(';').strip().lower().split())
+    sql = ISQL_META_COMMANDS.get(key)
+    if sql is not None:
+        return sql
+    # 2) show table NAME (column list).
+    m = SHOW_TABLE_RE.match(stripped)
+    if m:
+        name = _validated_object_name(m)
+        return SHOW_TABLE_SQL.format(name=name) if name is not None else None
+    # 3) show procedure/view/trigger/function NAME (object source).
+    m = SHOW_SOURCE_RE.match(stripped)
+    if m:
+        name = _validated_object_name(m)
+        if name is None:
+            return None
+        table, name_col, source_col = SOURCE_OBJECTS[m.group('kind').lower()]
+        return ("SELECT {col} AS SOURCE FROM {tbl} "
+                "WHERE {namecol} = '{name}'").format(
+                    col=source_col, tbl=table, namecol=name_col, name=name)
+    return None
+
+
+def source_object_name(query_string):
+    """Return the validated name if query_string is a "show <kind> NAME"
+    command that returns an object's source (procedure/view/trigger/
+    function), else None.
+
+    The DA layer (Connection.manage_testForm) uses this to recognise such
+    commands and render the source with whitespace preserved; the SQL
+    translation itself happens in translate_isql_meta() above.
+    """
+    m = SHOW_SOURCE_RE.match(query_string.strip())
+    if m is None:
+        return None
+    return _validated_object_name(m)

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,12 @@ FirebirdDA
 FirebirdDA https://github.com/nakagami/Products.FirebirdDA is Zope database
 adapter for Interbase/Firebird.
 
+Requirements
+------------
+
+- Python >= 3.11
+- Zope 5
+
 Installation
 -----------------
 
@@ -12,4 +18,76 @@ buildout.cfg::
    eggs =
        ...
        Products.FirebirdDA
+
+Driver Configuration
+--------------------
+
+FirebirdDA supports two Firebird Python drivers:
+
+- ``firebirdsql`` (default, auto-detected)
+- ``firebird-driver``
+
+Set the ``FIREBIRDDA_DRIVER`` environment variable to select a driver
+explicitly.  In a Zope deployment this is typically done in ``zope.conf``::
+
+   <environment>
+     FIREBIRDDA_DRIVER firebird-driver
+   </environment>
+
+If the variable is not set, FirebirdDA auto-detects: it tries to import
+``firebirdsql`` first and falls back to ``firebird-driver``.
+
+To use ``firebird-driver``, install it as an extra::
+
+   pip install Products.FirebirdDA[firebird-driver]
+
+Connection String
+-----------------
+
+The connection string uses space-separated ``key=value`` pairs::
+
+   dsn=host:/path/to/database.fdb user=sysdba password=masterkey
+
+The ``dsn``, ``user`` and ``password`` keys are passed directly to the
+driver's ``connect()`` function.  When using ``firebird-driver``, the
+DSN is automatically converted from ``firebirdsql`` format
+(``host:/path``) to ``firebird-driver`` format (``host:path``).
+
+Driver Differences
+------------------
+
+The two drivers differ in how they return fixed-length ``CHAR(n)``
+values:
+
+- ``firebirdsql`` strips trailing spaces from ``CHAR`` columns
+  automatically (``xsqlvar.py``: ``SQL_TYPE_TEXT`` → ``rstrip()``).
+- ``firebird-driver`` returns ``CHAR`` values padded to the declared
+  column width, as delivered by the Firebird wire protocol.
+
+When switching from ``firebirdsql`` to ``firebird-driver``, code that
+compares or displays ``CHAR`` values may need explicit ``rstrip()``
+calls, or the column can be migrated from ``CHAR(n)`` to
+``VARCHAR(n)``.
+
+Test Tab
+--------
+
+The ZMI Test tab supports ISQL-style meta commands (requires the
+Test Database Connections permission):
+
+- ``show tables`` — list all user tables
+- ``show table NAME`` — show columns of a table
+- ``show views`` — list all user views
+- ``show view NAME`` — show the view source
+- ``show procedures`` — list all stored procedures
+- ``show procedure NAME`` — show the procedure source
+- ``show functions`` — list all user functions
+- ``show function NAME`` — show the function source (Firebird 3+)
+- ``show triggers`` — list all user triggers
+- ``show trigger NAME`` — show the trigger source
+- ``show generators`` — list all generators (sequences)
+- ``show domains`` — list all user domains
+- ``show exceptions`` — list all user exceptions
+- ``show version`` — show Firebird engine version
+- ``show database`` — show database name, engine version and current user
 

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,32 @@
+from pathlib import Path
+
 from setuptools import setup, find_packages
 
 version = '0.7.1'
 
+here = Path(__file__).parent
+long_description = (
+    here.joinpath('README.rst').read_text(encoding='utf-8')
+    + '\n\n'
+    + here.joinpath('CHANGES.rst').read_text(encoding='utf-8')
+)
+
 setup(name='Products.FirebirdDA',
       version=version,
-      description="Firebird database adapter for Zope4",
-      long_description=open("README.rst").read(),
+      description="Firebird database adapter for Zope 5",
+      long_description=long_description,
+      long_description_content_type='text/x-rst',
       # Get more strings from
       # http://pypi.python.org/pypi?:action=list_classifiers
       classifiers=[
         "Programming Language :: Python",
-        "Framework :: Zope :: 4",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Framework :: Zope :: 5",
         "License :: OSI Approved :: Zope Public License",
+        "Operating System :: OS Independent",
         ],
       keywords='Firebird',
       author='Hajime Nakagami',
@@ -22,10 +37,14 @@ setup(name='Products.FirebirdDA',
       namespace_packages=['Products'],
       include_package_data=True,
       zip_safe=False,
+      python_requires='>=3.11',
       install_requires=[
           'firebirdsql',
           'Products.ZSQLMethods',
       ],
+      extras_require={
+          'firebird-driver': ['firebird-driver>=1.4.0'],
+      },
       entry_points="""
       # -*- Entry points: -*-
       """,


### PR DESCRIPTION
Adds optional support for the maintained firebird-driver package
alongside the existing firebirdsql driver.

The firebird-driver backend has been running in my production
environment without issues since the READ_COMMITTED fix in
early April 2026.

## Driver selection
The backend is chosen at import time via the FIREBIRDDA_DRIVER
environment variable (typically set in <environment> in zope.conf).
Auto-detect prefers firebirdsql when neither is requested, so existing
installs are unaffected.

- **firebirdsql** — autocommit, with the existing retry loop for
  transient errors (broken pipe, invalid handle, too many handles).
- **firebird-driver** — runs each query under READ_COMMITTED and commits
  afterwards (firebirdsql uses autocommit instead); a failed query is
  rolled back so it cannot leave a transaction open.

## Error handling
The driver now tells two kinds of failure apart:

- **Lost connections** (server restart, network drop, broken pipe) are
  recognised from Firebird's error codes and retried automatically after
  reconnecting, with a short pause between attempts.
- **SQL and logic errors** are not retried. The message carries the
  SQLSTATE/SQLCODE codes and is made HTML-safe, so the ZMI Test tab shows
  the real Firebird error instead of breaking while rendering a raw
  driver exception. Since the same query path also serves Z SQL Methods
  on application pages, the failing SQL is shown only to Managers, never
  to unprivileged users.

## ISQL Test-tab convenience
A small set of ISQL meta commands (`show tables`, `show procedure NAME`,
`show view/trigger/function NAME`, …) is translated to SQL. The
translation lives only in the Test tab, not in the shared query path, so
it never affects Z SQL Methods.

## Packaging
`python_requires >= 3.11`, 3.11–3.13 classifiers, and firebird-driver
as an optional extra so firebirdsql stays the default install.